### PR TITLE
Adjust nginx.tmpl to current ddev-router, fixes #5

### DIFF
--- a/.ddev/patches/ddev-router/nginx.tmpl
+++ b/.ddev/patches/ddev-router/nginx.tmpl
@@ -1,3 +1,4 @@
+## jonaseberle edition
 {{ $CurrentContainer := where $ "ID" .Docker.CurrentContainerID | first }}
 
 {{ define "upstream" }}
@@ -156,6 +157,7 @@ server {
 {{/* upstream {{ $upstream_name }} { */}}
 
 {{ range $container := $containers }}
+    ### Looking at {{ $container.Name }}
     {{/* HTTP_EXPOSE replaces the VIRTUAL_PORT var originally provided by jwilder/nginx-proxy. */}}
     {{/* HTTP_EXPOSE provides comma-separated ports to serve for container. Ports can be defined as hostPort:containerPort */}}
     {{ $ports := coalesce $container.Env.HTTP_EXPOSE "80" }}
@@ -174,7 +176,7 @@ server {
     {{ range $containerNetwork := $container.Networks }}
         ## checking containerNetwork="{{ $containerNetwork.Name }}"
         {{ if (ne $containerNetwork.Name "ingress") }}
-            ## Can be connect with "{{ $containerNetwork.Name }}" network
+            ## Can be connected with "{{ $containerNetwork.Name }}" network
 
             {{/* If only 1 port exposed, use that */}}
             {{ if eq $addrLen 1 }}

--- a/.ddev/patches/ddev-router/nginx.tmpl
+++ b/.ddev/patches/ddev-router/nginx.tmpl
@@ -1,6 +1,4 @@
-### finding ID= {{ .Docker.CurrentContainerID }}
 {{ $CurrentContainer := where $ "ID" .Docker.CurrentContainerID | first }}
-### CurrentContainer= {{ $CurrentContainer }}
 
 {{ define "upstream" }}
 	{{ if .Address }}
@@ -39,9 +37,6 @@ map $http_upgrade $proxy_connection {
   default upgrade;
   '' close;
 }
-
-# Apply fix for very long server names
-server_names_hash_bucket_size 128;
 
 # Default dhparam
 # ssl_dhparam /etc/nginx/dhparam/dhparam.pem;
@@ -91,11 +86,12 @@ proxy_set_header Proxy "";
 {{ $default_cert := trimSuffix ".crt" $default_cert }}
 {{ $default_cert := trimSuffix ".key" $default_cert }}
 server {
-	server_name _; # This is just an invalid value which will never trigger on a real hostname.
-	listen 80;
-	{{ if $enable_ipv6 }}
-	listen [::]:80;
-	{{ end }}
+	server_name _; # Catch-all for any server_name that is not matched in the config
+
+    # Listen on all configured http ports + 80 (HTTPS_EXPOSE)
+    # So that we can redirect any server_name that is invalid
+
+	include /tmp/http_ports.conf;
 	access_log /var/log/nginx/access.log vhost;
 
     error_page 503 @noupstream;
@@ -115,36 +111,40 @@ server {
     }
 }
 
-{{ if exists (printf "/etc/nginx/certs/%s.crt" $default_cert) }}
-server {
-	server_name _; # This is just an invalid value which will never trigger on a real hostname.
-	listen 443 ssl http2;
-	{{ if $enable_ipv6 }}
-	listen [::]:443 ssl http2;
-	{{ end }}
-	access_log /var/log/nginx/access.log vhost;
+ {{ if exists (printf "/etc/nginx/certs/%s.crt" $default_cert) }}
+ server {
+ 	server_name _; # Catch-all for any server_name that is not matched in the config
 
-    error_page 503 @noupstream;
-    location @noupstream {
-        rewrite ^(.*)$ /503.html break;
-        root /app;
-    }
+ 	# Listen on all configured https ports + 443 (HTTPS_EXPOSE)
+ 	# So that we can redirect any server_name that is invalid
+	include /tmp/https_ports.conf;
 
-    location / {
-        return 503;
-    }
-
-    ## provide a health check endpoint
-    location = /healthcheck {
-        access_log off;
-        return 200;
-    }
-
-	ssl_session_tickets off;
-    ssl_certificate /etc/nginx/certs/{{ (printf "%s.crt" $default_cert) }};
-    ssl_certificate_key /etc/nginx/certs/{{ (printf "%s.key" $default_cert) }};
-}
-{{ end }}
+ 	{{ if $enable_ipv6 }}
+ 	listen [::]:443 ssl http2;
+ 	{{ end }}
+ 	access_log /var/log/nginx/access.log vhost;
+ 
+     error_page 503 @noupstream;
+     location @noupstream {
+         rewrite ^(.*)$ /503.html break;
+         root /app;
+     }
+ 
+     location / {
+         return 503;
+     }
+ 
+     ## provide a health check endpoint
+     location = /healthcheck {
+         access_log off;
+         return 200;
+     }
+ 
+ 	ssl_session_tickets off;
+     ssl_certificate /etc/nginx/certs/{{ (printf "%s.crt" $default_cert) }};
+     ssl_certificate_key /etc/nginx/certs/{{ (printf "%s.key" $default_cert) }};
+ }
+ {{ end }}
 
 {{ range $host, $containers := groupByMulti $ "Env.VIRTUAL_HOST" "," }}
 
@@ -156,9 +156,7 @@ server {
 {{/* upstream {{ $upstream_name }} { */}}
 
 {{ range $container := $containers }}
-    ### we are at container= {{ $container.Name }}
-
-    {{/* This replaces the VIRTUAL_PORT var originally provided by jwilder/nginx-proxy. */}}
+    {{/* HTTP_EXPOSE replaces the VIRTUAL_PORT var originally provided by jwilder/nginx-proxy. */}}
     {{/* HTTP_EXPOSE provides comma-separated ports to serve for container. Ports can be defined as hostPort:containerPort */}}
     {{ $ports := coalesce $container.Env.HTTP_EXPOSE "80" }}
     {{ $ports := split $ports "," }}
@@ -169,9 +167,10 @@ server {
 
     # {{ $host }}
     upstream {{ $upstream_name }}-{{ $upstream_port }} {
-
+    keepalive 100;
 	{{ $addrLen := len $container.Addresses }}
 
+    # jonaseberle/github-action-setup-ddev version (patched)
     {{ range $containerNetwork := $container.Networks }}
         ## checking containerNetwork="{{ $containerNetwork.Name }}"
         {{ if (ne $containerNetwork.Name "ingress") }}
@@ -209,7 +208,7 @@ server {
 {{/* Get the VIRTUAL_ROOT By containers w/ use fastcgi root */}}
 {{ $vhost_root := or (first (groupByKeys $containers "Env.VIRTUAL_ROOT")) "/var/www/public" }}
 
-# Use a single master.crt/master.key
+# Default to a single master.crt/master.key
 {{ $cert := "master" }}
 
 {{ range $container := whereExist $containers "Env.HTTP_EXPOSE" }}
@@ -266,6 +265,7 @@ server {
                 proxy_buffers   4 256k;
                 proxy_busy_buffers_size   256k;
                 proxy_read_timeout 10m;
+                proxy_http_version 1.1;
                 proxy_pass {{ trim $proto }}://{{ trim $upstream_name }}-{{ trim $upstream_port }};
                 {{ end }}
                 error_page 502 @brokenupstream;
@@ -320,16 +320,21 @@ server {
             deny all;
             {{ end }}
 
-            ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-            ssl_ciphers 'ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:!DSS';
-
             ssl_prefer_server_ciphers on;
             ssl_session_timeout 5m;
             ssl_session_cache shared:SSL:50m;
             ssl_session_tickets off;
 
+            {{ if (exists (printf "/mnt/ddev-global-cache/custom_certs/%s.crt" $host)) }}
+            ssl_certificate /mnt/ddev-global-cache/custom_certs/{{ (printf "%s.crt" $host) }};
+            ssl_certificate_key /mnt/ddev-global-cache/custom_certs/{{ (printf "%s.key" $host) }};
+            {{ else if (exists (printf "/etc/letsencrypt/live/%s/fullchain.pem" $host)) }}
+            ssl_certificate /etc/letsencrypt/live/{{ $host }}/fullchain.pem;
+            ssl_certificate_key /etc/letsencrypt/live/{{ $host }}/privkey.pem;
+            {{ else }}
             ssl_certificate /etc/nginx/certs/{{ (printf "%s.crt" $cert) }};
             ssl_certificate_key /etc/nginx/certs/{{ (printf "%s.key" $cert) }};
+            {{ end }}
 
             {{ if (exists (printf "/etc/nginx/certs/%s.dhparam.pem" $cert)) }}
             ssl_dhparam {{ printf "/etc/nginx/certs/%s.dhparam.pem" $cert }};
@@ -364,6 +369,7 @@ server {
                 proxy_buffers   4 256k;
                 proxy_busy_buffers_size   256k;
                 proxy_read_timeout 10m;
+                proxy_http_version 1.1;
                 proxy_pass {{ trim $proto }}://{{ trim $upstream_name }}-{{ trim $upstream_port }};
                 {{ end }}
                 error_page 502 @brokenupstream;

--- a/.ddev/patches/ddev-router/router-compose.nginx_tmpl.yaml
+++ b/.ddev/patches/ddev-router/router-compose.nginx_tmpl.yaml
@@ -1,0 +1,7 @@
+# This override puts the nginx.tmpl customized for github actions into ~/.ddev
+version: '3.6'
+services:
+  ddev-router:
+    volumes:
+    - ./nginx.tmpl:/app/nginx.tmpl
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,4 +10,4 @@ jobs:
         os: [ubuntu-16.04, ubuntu-18.04]
     steps:
       - uses: actions/checkout@v1
-      - uses: jonaseberle/github-action-setup-ddev@master
+      - uses: rfay/github-action-setup-ddev@20201122_update_to_ddev_1.16

--- a/lib/main.js
+++ b/lib/main.js
@@ -56,36 +56,13 @@ function execShellCommand(cmd) {
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
-            yield execShellCommand('echo \'dir: ' + __dirname + '\'');
-            let cmd = 'curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -';
+            let cmd = 'sudo apt-get -qq update && sudo apt-get -qq -y install libnss3-tools';
             console.log(cmd);
             yield execShellCommand(cmd);
-            cmd = 'sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"';
+            cmd = 'curl -LO https://raw.githubusercontent.com/drud/ddev/master/scripts/install_ddev.sh && bash install_ddev.sh\n';
             console.log(cmd);
             yield execShellCommand(cmd);
-            cmd = 'sudo apt-get update';
-            console.log(cmd);
-            yield execShellCommand(cmd);
-            cmd = 'sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce libnss3-tools';
-            console.log(cmd);
-            yield execShellCommand(cmd);
-            core.addPath('/home/linuxbrew/.linuxbrew/bin');
-            cmd = '/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Linuxbrew/install/master/install.sh)"';
-            console.log(cmd);
-            yield execShellCommand(cmd);
-            cmd = 'brew tap drud/ddev';
-            console.log(cmd);
-            yield execShellCommand(cmd);
-            cmd = 'brew install ddev docker-compose mkcert nss';
-            console.log(cmd);
-            yield execShellCommand(cmd);
-            cmd = 'mkcert -install';
-            console.log(cmd);
-            yield execShellCommand(cmd);
-            cmd = 'ddev config global --instrumentation-opt-in=false';
-            console.log(cmd);
-            yield execShellCommand(cmd);
-            cmd = 'ddev config global --omit-containers=dba,ddev-ssh-agent';
+            cmd = 'ddev config global --instrumentation-opt-in=false --omit-containers=dba,ddev-ssh-agent';
             console.log(cmd);
             yield execShellCommand(cmd);
             let _nginxTmplPath = path.join(__dirname, '..', '.ddev', 'patches', 'ddev-router', 'nginx.tmpl');

--- a/lib/main.js
+++ b/lib/main.js
@@ -65,11 +65,13 @@ function run() {
             cmd = 'ddev config global --instrumentation-opt-in=false --omit-containers=dba,ddev-ssh-agent';
             console.log(cmd);
             yield execShellCommand(cmd);
-            let _nginxTmplPath = path.join(__dirname, '..', '.ddev', 'patches', 'ddev-router', 'nginx.tmpl');
-            cmd = 'ddev start || ( ' +
-                '    docker cp ' + _nginxTmplPath + ' ddev-router:/app/nginx.tmpl ' +
-                '    && ddev start ' +
-                ')';
+            
+            // Github actions requires a patched nginx.tmpl, which may change in ddev as well
+            let _pathPath = path.join(__dirname, '..', '.ddev', 'patches', 'ddev-router');
+            cmd = 'cp ' + _pathPath + '/* ~/.ddev'
+            console.log(cmd);
+            yield execShellCommand(cmd);
+            cmd = 'ddev start'
             console.log(cmd);
             yield execShellCommand(cmd);
         }

--- a/src/main.ts
+++ b/src/main.ts
@@ -30,10 +30,7 @@ function execShellCommand(cmd: string): Promise<string> {
 async function run() {
     try {
         await execShellCommand('echo \'dir: ' + __dirname + '\'');
-        let cmd = 'sudo apt-get update'
-        console.log(cmd);
-        await execShellCommand(cmd);
-        cmd = 'sudo apt-get -y -o Dpkg::Options::="--force-confnew" install libnss3-tools'
+        let cmd = 'sudo apt-get update -qq && apt-get -qq -y -o Dpkg::Options::="--force-confnew" install libnss3-tools'
         console.log(cmd);
         await execShellCommand(cmd);
         cmd = 'curl -LO https://raw.githubusercontent.com/drud/ddev/master/scripts/install_ddev.sh && bash install_ddev.sh\n';

--- a/src/main.ts
+++ b/src/main.ts
@@ -30,36 +30,16 @@ function execShellCommand(cmd: string): Promise<string> {
 async function run() {
     try {
         await execShellCommand('echo \'dir: ' + __dirname + '\'');
-
-        let cmd = 'curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -';
+        let cmd = 'sudo apt-get update'
         console.log(cmd);
         await execShellCommand(cmd);
-        cmd = 'sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"';
+        cmd = 'sudo apt-get -y -o Dpkg::Options::="--force-confnew" install libnss3-tools'
         console.log(cmd);
         await execShellCommand(cmd);
-        cmd = 'sudo apt-get update'
+        cmd = 'curl -LO https://raw.githubusercontent.com/drud/ddev/master/scripts/install_ddev.sh && bash install_ddev.sh\n';
         console.log(cmd);
         await execShellCommand(cmd);
-        cmd = 'sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce libnss3-tools'
-        console.log(cmd);
-        await execShellCommand(cmd);
-        core.addPath('/home/linuxbrew/.linuxbrew/bin');
-        cmd = '/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Linuxbrew/install/master/install.sh)"';
-        console.log(cmd);
-        await execShellCommand(cmd);
-        cmd = 'brew tap drud/ddev';
-        console.log(cmd);
-        await execShellCommand(cmd);
-        cmd = 'brew install ddev docker-compose mkcert nss';
-        console.log(cmd);
-        await execShellCommand(cmd);
-        cmd = 'mkcert -install';
-        console.log(cmd);
-        await execShellCommand(cmd);
-        cmd = 'ddev config global --instrumentation-opt-in=false';
-        console.log(cmd);
-        await execShellCommand(cmd);
-        cmd = 'ddev config global --omit-containers=dba,ddev-ssh-agent';
+        cmd = 'ddev config global --instrumentation-opt-in=false --omit-containers=dba,ddev-ssh-agent';
         console.log(cmd);
         await execShellCommand(cmd);
         let _nginxTmplPath = path.join(__dirname, '..', '.ddev', 'patches', 'ddev-router', 'nginx.tmpl');

--- a/src/main.ts
+++ b/src/main.ts
@@ -30,7 +30,7 @@ function execShellCommand(cmd: string): Promise<string> {
 async function run() {
     try {
         await execShellCommand('echo \'dir: ' + __dirname + '\'');
-        let cmd = 'sudo apt-get update -qq && apt-get -qq -y -o Dpkg::Options::="--force-confnew" install libnss3-tools'
+        let cmd = 'sudo apt-get -qq update && sudo apt-get -qq -y install libnss3-tools'
         console.log(cmd);
         await execShellCommand(cmd);
         cmd = 'curl -LO https://raw.githubusercontent.com/drud/ddev/master/scripts/install_ddev.sh && bash install_ddev.sh\n';


### PR DESCRIPTION
The nginx.tmpl pushed into ddev-router was quite old and needed to be updated to match current ddev v1.16.1

This also
* Simplifies the ddev installation and removes use of homebrew
* Stops installing docker and docker-compose as they're already there

I just had to do those because I was waiting too long for everything, sorry to do them in this PR.

What we really need to do though is to debug the original problem, so that will come next. It's also possible now to do something much more elegant than the `docker cp` and we can override the configuration for ddev-router. So at the very least we can do that. 