### PR TITLE
Silence the cURL output unless it fails

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -59,7 +59,7 @@ function run() {
             const ddevDir = core.getInput('ddevDir') || '.';
             const autostart = core.getBooleanInput('autostart');
             yield execShellCommand('echo \'dir: ' + __dirname + '\'');
-            let cmd = 'curl https://apt.fury.io/drud/gpg.key | sudo apt-key add -';
+            let cmd = 'curl -fsSL https://apt.fury.io/drud/gpg.key | sudo apt-key add -';
             console.log(cmd);
             yield execShellCommand(cmd);
             cmd = 'echo "deb https://apt.fury.io/drud/ * *" | sudo tee -a /etc/apt/sources.list.d/ddev.list';


### PR DESCRIPTION
cURL causes about 100 extra lines of output to show the progress of the download, let's just hide it unless it fails. `-fsSL` is the standard set of arguments to use with cURL.