### PR TITLE
Deprecate action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: 'Setup ddev'
+name: 'Setup ddev (deprecated)'
 description: 'Set up your GitHub Actions workflow with ddev '
 author: 'Jonas Eberle'
 runs:


### PR DESCRIPTION
We need to rename the action name in order to re-use the action name with https://github.com/[ddev/github-action-setup-ddev.

See https://github.com/ddev/github-action-setup-ddev/issues/8